### PR TITLE
Improve the "slot" syntax in Svelte. Other improvements for Svelte and TypeScript.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "respectmyeyes",
-  "version": "4.0.3-beta.1",
+  "version": "4.0.3-beta.2",
   "displayName": "RespectMyEyes theme",
   "description": "A light theme that respects your eyes.",
   "publisher": "dima-iholkin",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "respectmyeyes",
-  "version": "4.0.3-beta.2",
+  "version": "4.0.3-beta.3",
   "displayName": "RespectMyEyes theme",
   "description": "A light theme that respects your eyes.",
   "publisher": "dima-iholkin",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "respectmyeyes",
-  "version": "4.0.3-beta.3",
+  "version": "4.0.3-beta.4",
   "displayName": "RespectMyEyes theme",
   "description": "A light theme that respects your eyes.",
   "publisher": "dima-iholkin",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "respectmyeyes",
-  "version": "4.0.3-beta.4",
+  "version": "4.0.3-beta.5",
   "displayName": "RespectMyEyes theme",
   "description": "A light theme that respects your eyes.",
   "publisher": "dima-iholkin",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "respectmyeyes",
-  "version": "4.0.2",
+  "version": "4.0.3-beta.1",
   "displayName": "RespectMyEyes theme",
   "description": "A light theme that respects your eyes.",
   "publisher": "dima-iholkin",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "respectmyeyes",
-  "version": "4.0.3-beta.6",
+  "version": "4.0.3",
   "displayName": "RespectMyEyes theme",
   "description": "A light theme that respects your eyes.",
   "publisher": "dima-iholkin",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "respectmyeyes",
-  "version": "4.0.3-beta.5",
+  "version": "4.0.3-beta.6",
   "displayName": "RespectMyEyes theme",
   "description": "A light theme that respects your eyes.",
   "publisher": "dima-iholkin",

--- a/themes/RespectMyEyes-Light-color-theme.json
+++ b/themes/RespectMyEyes-Light-color-theme.json
@@ -2862,10 +2862,21 @@
     {
       "scope": [
         "meta.scope.tag.slot.svelte keyword.control.svelte", // "<slot />" tag
-        "meta.attribute.slot.svelte entity.other.attribute-name.svelte", // "slot" attribute
+        "meta.attribute.slot.svelte entity.other.attribute-name.svelte", // "slot"=name attribute in children tags
       ],
       "settings": {
         "foreground": "#0BC5E3",
+      }
+    },
+    //
+    // "slot" syntax:
+    {
+      "scope": [
+        "meta.attribute.slot.svelte string.quoted.svelte", // slot="name" attribute in children tags
+        "meta.scope.tag.slot.svelte meta.attribute.name.svelte string.quoted.svelte", // name="slot_name" attribute in slot tag
+      ],
+      "settings": {
+        "foreground": "#E8810C",
       }
     },
     //

--- a/themes/RespectMyEyes-Light-color-theme.json
+++ b/themes/RespectMyEyes-Light-color-theme.json
@@ -2555,6 +2555,16 @@
       }
     },
     //
+    // "< >" angle brackets for casting in TypeScript:
+    {
+      "scope": [
+        "cast.expr.ts meta.brace.angle.ts",
+      ],
+      "settings": {
+        "foreground": "#A9A9A9"
+      }
+    },
+    //
     // "` `" backticks in template string:
     {
       "scope": [

--- a/themes/RespectMyEyes-Light-color-theme.json
+++ b/themes/RespectMyEyes-Light-color-theme.json
@@ -2903,6 +2903,52 @@
       }
     },
     //
+    // <svelte:head>, <svelte:body>, <svelte:document> and similar tags in svelte components:
+    {
+      "scope": [
+        // <svelte:head>:
+        "meta.scope.tag.svelte:head.svelte meta.tag keyword.control.svelte", // "svelte"
+        "meta.scope.tag.svelte:head.svelte meta.tag punctuation.definition.tag.begin.svelte", // "<"
+        "meta.scope.tag.svelte:head.svelte meta.tag punctuation.definition.tag.end.svelte", // ">"
+        "meta.scope.tag.svelte:head.svelte meta.tag entity.name.tag.svelte", // "head"
+        // <svelte:body>:
+        "meta.scope.tag.svelte:body.svelte meta.tag keyword.control.svelte", // "svelte"
+        "meta.scope.tag.svelte:body.svelte meta.tag punctuation.definition.tag.begin.svelte", // "<"
+        "meta.scope.tag.svelte:body.svelte meta.tag punctuation.definition.tag.end.svelte", // ">"
+        "meta.scope.tag.svelte:body.svelte meta.tag entity.name.tag.svelte", // "body"
+        // <svelte:document>:
+        "meta.scope.tag.svelte:document.svelte meta.tag keyword.control.svelte", // "svelte"
+        "meta.scope.tag.svelte:document.svelte meta.tag punctuation.definition.tag.begin.svelte", // "<"
+        "meta.scope.tag.svelte:document.svelte meta.tag punctuation.definition.tag.end.svelte", // ">"
+        "meta.scope.tag.svelte:document.svelte meta.tag entity.name.tag.svelte", // "document"
+        // <svelte:window>:
+        "meta.scope.tag.svelte:window.svelte meta.tag keyword.control.svelte", // "svelte"
+        "meta.scope.tag.svelte:window.svelte meta.tag punctuation.definition.tag.begin.svelte", // "<"
+        "meta.scope.tag.svelte:window.svelte meta.tag punctuation.definition.tag.end.svelte", // ">"
+        "meta.scope.tag.svelte:window.svelte meta.tag entity.name.tag.svelte", // "window"
+      ],
+      "settings": {
+        "foreground": "#8080E6" // #0000CC80
+      }
+    },
+    //
+    // fix the directives like "on:" after the previous rule applied:
+    {
+      "scope": [
+        // <svelte:head>:
+        "meta.scope.tag.svelte:head.svelte meta.tag meta.directive keyword.control.svelte",
+        // <svelte:body>:
+        "meta.scope.tag.svelte:body.svelte meta.tag meta.directive keyword.control.svelte",
+        // <svelte:document>:
+        "meta.scope.tag.svelte:document.svelte meta.tag meta.directive keyword.control.svelte",
+        // <svelte:window>:
+        "meta.scope.tag.svelte:window.svelte meta.tag meta.directive keyword.control.svelte",
+      ],
+      "settings": {
+        "foreground": "#C344AB"
+      }
+    },
+    //
     // "export" keyword for props:
     {
       "scope": [

--- a/themes/RespectMyEyes-Light-color-theme.json
+++ b/themes/RespectMyEyes-Light-color-theme.json
@@ -2926,6 +2926,11 @@
         "meta.scope.tag.svelte:window.svelte meta.tag punctuation.definition.tag.begin.svelte", // "<"
         "meta.scope.tag.svelte:window.svelte meta.tag punctuation.definition.tag.end.svelte", // ">"
         "meta.scope.tag.svelte:window.svelte meta.tag entity.name.tag.svelte", // "window"
+        // <svelte:options>:
+        "meta.scope.tag.svelte:options.svelte meta.tag keyword.control.svelte", // "svelte"
+        "meta.scope.tag.svelte:options.svelte meta.tag punctuation.definition.tag.begin.svelte", // "<"
+        "meta.scope.tag.svelte:options.svelte meta.tag punctuation.definition.tag.end.svelte", // ">"
+        "meta.scope.tag.svelte:options.svelte meta.tag entity.name.tag.svelte", // "options"
       ],
       "settings": {
         "foreground": "#8080E6" // #0000CC80
@@ -2943,6 +2948,8 @@
         "meta.scope.tag.svelte:document.svelte meta.tag meta.directive keyword.control.svelte",
         // <svelte:window>:
         "meta.scope.tag.svelte:window.svelte meta.tag meta.directive keyword.control.svelte",
+        // <svelte:options>:
+        "meta.scope.tag.svelte:options.svelte meta.tag meta.directive keyword.control.svelte",
       ],
       "settings": {
         "foreground": "#C344AB"

--- a/themes/RespectMyEyes-Light-color-theme.json
+++ b/themes/RespectMyEyes-Light-color-theme.json
@@ -2934,6 +2934,17 @@
       }
     },
     //
+    // "@component" documentation keyword:
+    {
+      "scope": [
+        "keyword.declaration.class.component.svelte", // "component"
+        "punctuation.definition.keyword.svelte", // "@"
+      ],
+      "settings": {
+        "foreground": "#C344AB",
+      }
+    },
+    //
     // "use:enhance" and similar:
     {
       "scope": [

--- a/themes/RespectMyEyes-Light-color-theme.json
+++ b/themes/RespectMyEyes-Light-color-theme.json
@@ -2923,6 +2923,16 @@
       }
     },
     //
+    // "( )" key notation in #each blocks:
+    {
+      "scope": [
+        "meta.special.each.svelte meta.special.start.svelte meta.brace.round.svelte",
+      ],
+      "settings": {
+        "foreground": "#C344AB",
+      }
+    },
+    //
     // "@debug" keyword:
     {
       "scope": [
@@ -2938,7 +2948,7 @@
     {
       "scope": [
         "keyword.declaration.class.component.svelte", // "component"
-        "punctuation.definition.keyword.svelte", // "@"
+        "comment.block.svelte punctuation.definition.keyword.svelte", // "@"
       ],
       "settings": {
         "foreground": "#C344AB",


### PR DESCRIPTION
* Fix the angle brackets "< >" for casting in TypeScript.
* Fix color for "@component" in Svelte.
* Add a semi-transparent color for tags like "<svelte:head>".
* Improve "#each" block's key notation "( )" in Svelte.