### PR TITLE
Add a lazy Go and Rust support.

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,9 +14,9 @@
 
 Core supported languages: 
 * Svelte
-* C# / .NET / ASP.NET Core
-* TypeScript / JavaScript
+* JavaScript / TypeScript
 * React / JSX / TSX 
+* C# / .NET / ASP.NET Core
 * CSS
 * HTML / XML
 * JSON
@@ -38,11 +38,11 @@ Source: <a href="https://github.com/dima-iholkin/PourOverPotato/blob/main/src/ro
 
 Source: <a href="https://github.com/dima-iholkin/PourOverPotato/blob/main/src/lib/UI/layout/components/MySidebar.svelte">PourOverPotato</a>
 
-### C#
+### JavaScript
 
-<img src="/screenshots/csharp.png" loading="lazy" title="screenshot of C# code styled by RespectMyEyes theme" />
+<img src="/screenshots/javascript.png" loading="lazy" width="700" title="screenshot of JavaScript code styled by RespectMyEyes theme" />
 
-Source: <a href="https://github.com/dima-iholkin/TogglPotato/blob/main/TogglPotato.WebAPI/StartupTests/StartupTester.cs">TogglPotato</a>
+Source: <a href="https://github.com/bradtraversy/modern_portfolio/blob/master/dist/js/main.js">Brad Traversy's Modern Portfolio</a>
 
 ### TypeScript
 
@@ -50,17 +50,17 @@ Source: <a href="https://github.com/dima-iholkin/TogglPotato/blob/main/TogglPota
 
 Source: <a href="https://github.com/dima-iholkin/PourOverPotato/blob/main/src/lib/domain/helpers/sortRecipes.ts">PourOverPotato</a>
 
-### JavaScript
-
-<img src="/screenshots/javascript.png" loading="lazy" width="700" title="screenshot of JavaScript code styled by RespectMyEyes theme" />
-
-Source: <a href="https://github.com/bradtraversy/modern_portfolio/blob/master/dist/js/main.js">Brad Traversy's Modern Portfolio</a>
-
 ### React / JSX / TSX
 
 <img src="/screenshots/react.png" loading="lazy" title="screenshot of React TSX code styled by RespectMyEyes theme" />
 
 Source: <a href="https://github.com/unlight/react-typescript-realworld-example-app/blob/master/src/components/Navbar.tsx">React TypeScript RealWorld Example App</a>
+
+### C#
+
+<img src="/screenshots/csharp.png" loading="lazy" title="screenshot of C# code styled by RespectMyEyes theme" />
+
+Source: <a href="https://github.com/dima-iholkin/TogglPotato/blob/main/TogglPotato.WebAPI/StartupTests/StartupTester.cs">TogglPotato</a>
 
 ### CSS
 
@@ -105,6 +105,14 @@ Source: <a href="https://github.com/dima-iholkin/TogglPotato/blob/main/README.md
       </td>
     </tr>
     <tr>
+      <td align="center">JavaScript / TypeScript</td>
+      <td align="center"> - </td>
+    </tr>
+    <tr>
+      <td align="center">React / JSX / TSX</td>
+      <td align="center"> - </td>
+    </tr>
+    <tr>
       <td align="center">C# / .NET / ASP.NET Core</td>
       <td align="center">
         <a href="https://marketplace.visualstudio.com/items?itemName=ms-dotnettools.csdevkit">C# Dev Kit</a>
@@ -115,14 +123,6 @@ Source: <a href="https://github.com/dima-iholkin/TogglPotato/blob/main/README.md
       <td align="center">
         <a href="https://marketplace.visualstudio.com/items?itemName=ms-dotnettools.csdevkit">C# Dev Kit</a>
       </td>
-    </tr>
-    <tr>
-      <td align="center">JavaScript / TypeScript</td>
-      <td align="center"> - </td>
-    </tr>
-    <tr>
-      <td align="center">React / JSX / TSX</td>
-      <td align="center"> - </td>
     </tr>
     <tr>
       <td align="center">CSS</td>
@@ -182,6 +182,18 @@ Maintainers for these and new languages are very welcome!
       </td>
     </tr>
     <tr>
+      <td align="center">Go</td>
+      <td align="center">
+        <a href="https://marketplace.visualstudio.com/items?itemName=golang.Go">Go</a>
+      </td>
+    </tr>
+    <tr>
+      <td align="center">Rust</td>
+      <td align="center">
+        <a href="https://marketplace.visualstudio.com/items?itemName=rust-lang.rust-analyzer">rust-analyzer</a>
+      </td>
+    </tr>
+    <tr>
       <td align="center">SQL</td>
       <td align="center"> - </td>
     </tr>
@@ -218,6 +230,12 @@ Maintainers for these and new languages are very welcome!
     <tr>
       <td align="center">YAML</td>
       <td align="center"> - </td>
+    </tr>
+    <tr>
+      <td align="center">TOML</td>
+      <td align="center">
+        <a href="https://marketplace.visualstudio.com/items?itemName=tamasfe.even-better-toml">Even Better TOML</a>
+      </td>
     </tr>
     <tr>
       <td align="center">Dockerfile</td>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "respectmyeyes",
-  "version": "5.0.1",
+  "version": "5.0.2",
   "displayName": "RespectMyEyes theme",
   "description": "A light theme that respects your eyes.",
   "publisher": "dima-iholkin",

--- a/themes/RespectMyEyes-Light-color-theme.json
+++ b/themes/RespectMyEyes-Light-color-theme.json
@@ -2951,6 +2951,17 @@
       "settings": {}
     },
     //
+    // "@render" syntax:
+    {
+      "scope": [
+        "meta.special.render.svelte keyword.other.svelte", // "render"
+        "meta.special.render.svelte punctuation.definition.keyword.svelte", // "@"
+      ],
+      "settings": {
+        "foreground": "#C344AB",
+      }
+    },
+    //
     // "svelte" tag keyword:
     {
       "scope": [

--- a/themes/RespectMyEyes-Light-color-theme.json
+++ b/themes/RespectMyEyes-Light-color-theme.json
@@ -220,6 +220,14 @@
     //
     //
     //
+    // Inlay Hints:
+    // Type and parameter information like what the Rust extension shows:
+    "editorInlayHint.background": "#C0C0C030",
+    "editorInlayHint.foreground": "#50A750",
+    //
+    //
+    //
+    //
     // the background behind the selection text when in another window or pane,
     // should be different from the active one:
     "editor.inactiveSelectionBackground": "#00B00020", // #DFF5DF
@@ -439,6 +447,7 @@
     {
       "scope": [
         "constant.language.boolean", // "true", "false"
+        "constant.language.bool", // "true", "false" for Rust
       ],
       "settings": {
         "foreground": "#A31515",
@@ -562,7 +571,7 @@
       }
     },
     //
-    // new Expression:
+    // "new" keyword:
     {
       "scope": [
         "new.expr",
@@ -783,6 +792,7 @@
     {
       "scope": [
         "keyword.operator.arithmetic", // +, -, *, /
+        "keyword.operator.math", // +, -, *, / for Rust
         "keyword.operator.assignment", // =
         "keyword.operator.increment", // ++
         "keyword.operator.decrement", // --
@@ -4234,7 +4244,8 @@
         "source.java meta.method-call punctuation.bracket.round",
       ],
       "settings": {
-        "foreground": "#0BC5E3",
+        // "foreground": "#0BC5E3", // disable because it's not working correctly
+        "foreground": "#A9A9A9",
       }
     },
     // The side-effect is that brackets in the "new" calls with generics are painted light-blue too,
@@ -4443,6 +4454,303 @@
     //
     //
     // ====================================================
+    // Rust (.rs):
+    //
+    // "mod", "use" import keywords:
+    // "const" variable keyword:
+    {
+      "scope": [
+        "storage.type.rust", // "mod", "const"
+        "meta.use.rust keyword.other.rust", // "use"
+      ],
+      "settings": {
+        "foreground": "#A9A9A9"
+      }
+    },
+    //
+    // keywords in Rust:
+    {
+      "scope": [
+        "source.rust keyword", // "crate" for example
+      ],
+      "settings": {
+        "foreground": "#A31515"
+      }
+    },
+    //
+    // "fn", "pub" and similar keywords:
+    {
+      "scope": [
+        "keyword.other.fn.rust", // "fn"
+        "keyword.other.rust", // "pub"
+      ],
+      "settings": {
+        "foreground": "#A31515"
+      }
+    },
+    //
+    // "struct", "enum", "type" keywords:
+    {
+      "scope": [
+        "keyword.declaration.struct.rust storage.type.rust", // "struct"
+        "keyword.declaration.enum.rust storage.type.rust", // "enum"
+        "keyword.declaration.type.rust storage.type.rust", // "type"
+      ],
+      "settings": {
+        "foreground": "#A31515"
+      }
+    },
+    //
+    // "let" variable keyword:
+    {
+      "scope": [
+        "keyword.other.rust storage.type.rust", // "let"
+      ],
+      "settings": {
+        "foreground": "#A9A9A9"
+      }
+    },
+    //
+    // storage modifier "mut" keyword:
+    {
+      "scope": [
+        "storage.modifier.mut.rust", // "mut"
+      ],
+      "settings": {
+        "foreground": "#A9A9A9"
+      }
+    },
+    //
+    // "self", "super" keywords:
+    {
+      "scope": [
+        "variable.language.self.rust",
+        "variable.language.super.rust",
+      ],
+      "settings": {
+        "foreground": "#C344AB"
+      }
+    },
+    //
+    // function definition name:
+    {
+      "scope": [
+        "meta.function.definition.rust entity.name.function.rust"
+      ],
+      "settings": {
+        "fontStyle": "bold"
+      }
+    },
+    //
+    // struct definition name:
+    {
+      "scope": [
+        "entity.name.type.struct.rust",
+        "entity.name.type.enum.rust"
+      ],
+      "settings": {
+        "foreground": "#0000CC",
+        "fontStyle": "bold"
+      }
+    },
+    //
+    // namespace name:
+    {
+      "scope": [
+        "entity.name.namespace.rust"
+      ],
+      "settings": {
+        "foreground": "#E8810C80"
+      }
+    },
+    //
+    // type name:
+    {
+      "scope": [
+        "source.rust entity.name.type"
+      ],
+      "settings": {
+        "foreground": "#E8810C"
+      }
+    },
+    //
+    // function parameter name:
+    {
+      "scope": [
+        "meta.function.definition.rust variable.other.rust"
+      ],
+      "settings": {
+        "foreground": "#C344AB"
+      }
+    },
+    //
+    // "&" borrow and "*" dereference operators:
+    {
+      "scope": [
+        "keyword.operator.borrow.and.rust",
+        "keyword.operator.dereference.rust"
+      ],
+      "settings": {
+        "foreground": "#C344AB"
+      }
+    },
+    //
+    // "->" return type punctuation in function definition:
+    {
+      "scope": [
+        "meta.function.definition.rust keyword.operator.arrow.skinny.rust"
+      ],
+      "settings": {
+        "foreground": "#A9A9A9",
+        "fontStyle": ""
+      }
+    },
+    //
+    // "=>" fat arrow in "match" block for example:
+    {
+      "scope": [
+        "keyword.operator.arrow.fat.rust"
+      ],
+      "settings": {
+        "foreground": "#A9A9A9",
+        "fontStyle": ""
+      }
+    },
+    //
+    // characters inside string interpolation "{ }":
+    {
+      "scope": [
+        "meta.interpolation.rust"
+      ],
+      "settings": {
+        "foreground": "#000000"
+      }
+    },
+    //
+    //
+    //
+    // ====================================================
+    // Go (.go):
+    //
+    // "package", "func" keywords:
+    {
+      "scope": [
+        "keyword.package.go",
+        "keyword.function.go",
+        "keyword.type.go",
+        "keyword.struct.go",
+        "source.go keyword" // "interface" and some others
+      ],
+      "settings": {
+        "foreground": "#A31515"
+      }
+    },
+    //
+    // "var" keyword:
+    {
+      "scope": [
+        "keyword.var.go",
+        "keyword.const.go"
+      ],
+      "settings": {
+        "foreground": "#A9A9A9"
+      }
+    },
+    //
+    // "map" keyword:
+    {
+      "scope": [
+        "keyword.map.go",
+      ],
+      "settings": {
+        "foreground": "#E8810C"
+      }
+    },
+    //
+    // package name:
+    {
+      "scope": [
+        "entity.name.type.package.go",
+      ],
+      "settings": {
+        "foreground": "#000000"
+      }
+    },
+    //
+    // type name during declaration:
+    {
+      "scope": [
+        "entity.name.type.go",
+      ],
+      "settings": {
+        "foreground": "#E8810C"
+      }
+    },
+    //
+    // type name:
+    {
+      "scope": [
+        "source.go storage.type",
+      ],
+      "settings": {
+        "foreground": "#E8810C"
+      }
+    },
+    //
+    // function name during declaratino:
+    {
+      "scope": [
+        "entity.name.function.go",
+      ],
+      "settings": {
+        "foreground": "#0000CC",
+        "fontStyle": "bold"
+      }
+    },
+    //
+    // property name in object syntax:
+    {
+      "scope": [
+        "variable.other.property.go",
+      ],
+      "settings": {
+        "foreground": "#C344AB",
+      }
+    },
+    //
+    // "true", "false" values:
+    {
+      "scope": [
+        "constant.language.go",
+      ],
+      "settings": {
+        "foreground": "#A31515"
+      }
+    },
+    //
+    // "%T", "%d" string placeholders:
+    {
+      "scope": [
+        "constant.other.placeholder.go",
+      ],
+      "settings": {
+        "foreground": "#0BC5E3"
+      }
+    },
+    //
+    // "&" pointer:
+    {
+      "scope": [
+        "keyword.operator.address.go",
+      ],
+      "settings": {
+        "foreground": "#C344AB"
+      }
+    },
+    //
+    //
+    //
+    // ====================================================
     // PowerShell (.ps1):
     //
     // type keyword declaration:
@@ -4620,7 +4928,7 @@
         "source.shell variable.other",
       ],
       "settings": {
-        "foreground": "#E8810C"
+        "foreground": "#C344AB"
       }
     },
     //
@@ -4630,7 +4938,7 @@
         "source.shell variable.other.assignment",
       ],
       "settings": {
-        "foreground": "#E8810C"
+        "foreground": "#C344AB"
       }
     },
     //

--- a/validation/validation_repos.md
+++ b/validation/validation_repos.md
@@ -9,17 +9,6 @@
 * [sveltejs/realworld](https://github.com/sveltejs/realworld)
 * [dima-iholkin/PourOverPotato](https://github.com/dima-iholkin/PourOverPotato)
 
-### C# / .NET / ASP.NET Core
-
-* [gothinkster/aspnetcore-realworld-example-app](https://github.com/gothinkster/aspnetcore-realworld-example-app)
-* [dima-iholkin/TogglPotato](https://github.com/dima-iholkin/TogglPotato)
-
-### C# Razor Pages / Blazor
-
-* [BrightSoul/RazorPagesSampleApp](https://github.com/BrightSoul/RazorPagesSampleApp)
-* [JeremyLikness/BlazorWasmEFCoreExample](https://github.com/JeremyLikness/BlazorWasmEFCoreExample)
-* [JBeni/BlazorShop](https://github.com/JBeni/BlazorShop)
-
 ### JavaScript, CSS, HTML
 
 * [bradtraversy/modern_portfolio](https://github.com/bradtraversy/modern_portfolio)
@@ -31,6 +20,17 @@
 ### React / JSX / TSX
 
 * [unlight/react-typescript-realworld-example-app](https://github.com/unlight/react-typescript-realworld-example-app)
+
+### C# / .NET / ASP.NET Core
+
+* [gothinkster/aspnetcore-realworld-example-app](https://github.com/gothinkster/aspnetcore-realworld-example-app)
+* [dima-iholkin/TogglPotato](https://github.com/dima-iholkin/TogglPotato)
+
+### C# Razor Pages / Blazor
+
+* [BrightSoul/RazorPagesSampleApp](https://github.com/BrightSoul/RazorPagesSampleApp)
+* [JeremyLikness/BlazorWasmEFCoreExample](https://github.com/JeremyLikness/BlazorWasmEFCoreExample)
+* [JBeni/BlazorShop](https://github.com/JBeni/BlazorShop)
 
 
 
@@ -54,6 +54,14 @@
 
 * [nomhoi/aiohttp-realworld-example-app](https://github.com/nomhoi/aiohttp-realworld-example-app)
 * [roboflow/supervision](https://github.com/roboflow/supervision)
+
+### Go
+
+* [opentofu](https://github.com/opentofu/opentofu)
+
+### Rust
+
+* [cloudflare/pingora](https://github.com/cloudflare/pingora)
 
 ### SQL
 


### PR DESCRIPTION
* Add support for "@render" syntax in Svelte 5.
* Update the README.md and validation repos for Go and Rust.
* Improve the inlay hints colors.
* Remove the light blue brackets for arrow functions in Java, as it's not working correctly.
* Change the variables color to purple for Shell scripts.